### PR TITLE
debug log

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -499,8 +499,13 @@ case class AdaptiveSparkPlanExec(
     sb.toString()
   }
 
-  private def q2s(qs: QueryStageExec): String =
-    s"${qs.productPrefix}(id: ${qs.id}, plan: ${qs.plan.productPrefix})"
+  private def q2s(qs: QueryStageExec): String = {
+    val ret = s"${qs.productPrefix}(id: ${qs.id}, "
+    qs.plan match {
+      case ex: Exchange => ret + s"${e2s(ex)})"
+      case _ => ret + s"plan: ${qs.plan.productPrefix})"
+    }
+  }
 
   private def m2s: String = context.stageCache.map { case (k, v) =>
     s"{${k.productPrefix}(hash: ${k.##}) -> ${q2s(v)}"

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -210,7 +210,7 @@ case class RelationConversions(
     val ret3 = (!r.isPartitioned || conf.getConf(HiveUtils.CONVERT_INSERTING_PARTITIONED_TABLE))
     val ret4 = isConvertible (r)
     logWarning(s"==>query.resolved: $ret1, isHiveTable: $ret2, isPartitionedEnabled: $ret3," +
-      s"isConvertible $ret4")
+      s" isConvertible $ret4")
     if (!ret2) {
       logWarning(s"==>not hive table due to its provider: ${r.tableMeta.provider}")
     }
@@ -226,6 +226,7 @@ case class RelationConversions(
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
+    logWarning("==>start relation conversion for hive")
     plan resolveOperators {
       // Write path
       case InsertIntoStatement(


### PR DESCRIPTION
Debug log for two issues:

1. Exchange can not be reused
2. InsertIntoHiveTable can not be converted

```
23/12/28 10:35:26 WARN RelationConversions: ==>start relation conversion for hive
23/12/28 10:35:26 WARN RelationConversions: ==>query.resolved: true, isHiveTable: true, isPartitionedEnabled: true,isConvertible false
23/12/28 10:35:26 WARN RelationConversions: ==>not convertible due to its serde is org.apache.hadoop.hive.serde2.lazy.lazysimpleserde
23/12/28 10:35:27 WARN GpuOverrides: 
!Exec <DataWritingCommandExec> cannot run on GPU because not all data writing commands can be replaced
  !Output <InsertIntoHiveTable> cannot run on GPU because writing Hive delimited text tables has been disabled, to enable this, set spark.rapids.sql.format.hive.text.write.enabled to true

23/12/28 10:35:27 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: try to fix up a spark plan Execute InsertIntoHiveTable
23/12/28 10:35:27 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: Start to look at reused exchange ...
23/12/28 10:35:27 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: reuse exchange enabled ?= true with input plan Execute InsertIntoHiveTable, current Map: 
    
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==> Got an exchange ShuffleExchangeExec(id: 133, canonicalized hash: 1135070750), current cache map:
    
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==>No cached stage can be reused, create a new one
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==> Got an exchange ShuffleExchangeExec(id: 129, canonicalized hash: -369184916), current cache map:
    
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==>No cached stage can be reused, create a new one
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==> Got an exchange ShuffleExchangeExec(id: 125, canonicalized hash: -1759962333), current cache map:
    
23/12/28 10:35:27 WARN AdaptiveSparkPlanExec: ==>No cached stage can be reused, create a new one
```